### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1659685697,
-        "narHash": "sha256-ASIu+L64CBtpacyzp4FV72fWcJMuwhSS7ZKda9lp8SE=",
+        "lastModified": 1659896399,
+        "narHash": "sha256-voloGBuFNKuBbXm3KZYPVBTG/WLjcVbHbvxakmirxdk=",
         "owner": "X01A",
         "repo": "nixos",
-        "rev": "bfdf8a890d893e5fd20cfdf658476e740cbdfcf6",
+        "rev": "09c273c9c8da4a7ff0b599d8d17a95d26b01148b",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659526864,
-        "narHash": "sha256-XFzXrc1+6DZb9hBgHfEzfwylPUSqVFJbQPs8eOgYufU=",
+        "lastModified": 1660215038,
+        "narHash": "sha256-tqMyd5QB4MZh59wMHXqpro4hkKjz9ubQxkxFSuCuBGE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "478f3cbc8448b5852539d785fbfe9a53304133be",
+        "rev": "45c9736ed69800a6ff2164fb4538c9e40dad25d6",
         "type": "github"
       },
       "original": {
@@ -139,13 +139,13 @@
     },
     "nixpkgs-channel": {
       "locked": {
-        "narHash": "sha256-THi3p35NoDAUzo7b2D0vaXeSM4RdNn/zgM+I1kx4stM=",
+        "narHash": "sha256-7i43s/2egM6+2RJ9NWz/es/qfUX3u42ONDH7RYjeL64=",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.2199.478f3cbc844/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.2361.45c9736ed69/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.2199.478f3cbc844/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.2361.45c9736ed69/nixexprs.tar.xz"
       }
     },
     "npmlock2nix": {
@@ -166,11 +166,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1659769539,
-        "narHash": "sha256-S6Ju/8r9HW1IP/pGMvi8iLLTIJvxMnR4XdmfVTjk5Vo=",
+        "lastModified": 1660331633,
+        "narHash": "sha256-rPkUpdTGTWQYvETUMY/g18j0CZImDkuXvagkWkNmczs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ad63cf18c521b5935900ec388ab2c0f59581be7",
+        "rev": "1804130c158ee8c21d86ded125f0f21cfd86cbef",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.2199.478f3cbc844/nixexprs.tar.xz";
+    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.2361.45c9736ed69/nixexprs.tar.xz";
 
     home-manager.url = "github:nix-community/home-manager/release-22.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'indexyz':
    'github:X01A/nixos/bfdf8a890d893e5fd20cfdf658476e740cbdfcf6' (2022-08-05)
  → 'github:X01A/nixos/09c273c9c8da4a7ff0b599d8d17a95d26b01148b' (2022-08-07)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/478f3cbc8448b5852539d785fbfe9a53304133be' (2022-08-03)
  → 'github:NixOS/nixpkgs/45c9736ed69800a6ff2164fb4538c9e40dad25d6' (2022-08-11)
• Updated input 'nixpkgs-channel':
    'https://releases.nixos.org/nixos/22.05/nixos-22.05.2199.478f3cbc844/nixexprs.tar.xz?narHash=sha256-THi3p35NoDAUzo7b2D0vaXeSM4RdNn%2fzgM+I1kx4stM='
  → 'https://releases.nixos.org/nixos/22.05/nixos-22.05.2361.45c9736ed69/nixexprs.tar.xz?narHash=sha256-7i43s%2f2egM6+2RJ9NWz%2fes%2fqfUX3u42ONDH7RYjeL64='
• Updated input 'nur':
    'github:nix-community/NUR/0ad63cf18c521b5935900ec388ab2c0f59581be7' (2022-08-06)
  → 'github:nix-community/NUR/1804130c158ee8c21d86ded125f0f21cfd86cbef' (2022-08-12)