### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,11 +98,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1661155543,
-        "narHash": "sha256-6PJ4wqDuFMIw34gM/LxQ9qZPw8vPls4xC7UCeweSvKs=",
+        "lastModified": 1661933071,
+        "narHash": "sha256-RFgfzldpbCvS+H2qwH+EvNejvqs+NhPVD5j1I7HQQPY=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "e7c6fbbe9076109263175ef992ca6edc1050973c",
+        "rev": "def994adbdfc28974e87b0e4c949e776207d5557",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1661541657,
-        "narHash": "sha256-XAmFKjTpkxbWBO1f/bmvJuIvxc4YvudXyigDAH/TSIw=",
+        "lastModified": 1661931841,
+        "narHash": "sha256-TsVYq1QV1SS8ax284Tc7qEEdGPFtLxvFbvsUu0i/0EM=",
         "owner": "X01A",
         "repo": "nixos",
-        "rev": "421614677e795290eb85dc491b0be559514ebe8f",
+        "rev": "0f3557cb90a1de3ac5ff947ffc443b1e04acf9c7",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661427965,
-        "narHash": "sha256-LJeSDbiebN0/eRt9vyOm+Bxljdsq5ZdalmmTk9Xpp30=",
+        "lastModified": 1662025319,
+        "narHash": "sha256-ZJlBQ7jXynq4+Jg9+DgOe8FJG8sDIeFFYP3V3K98KUs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "058de3818577db19d1965c21e2479916a3eaaf95",
+        "rev": "b82ccafb54163ab9024e893e578d840577785fea",
         "type": "github"
       },
       "original": {
@@ -154,13 +154,13 @@
     },
     "nixpkgs-channel": {
       "locked": {
-        "narHash": "sha256-im4r0AQIr5Zx1St0bMp54PdyzUhDEweBMLkxpK1p/tg=",
+        "narHash": "sha256-0dnMPICO1/3Kb2Z4GOnrAkO+Mtsf3THauqvxSKjM9jc=",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.2720.058de381857/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.2818.b82ccafb541/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.2720.058de381857/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.2818.b82ccafb541/nixexprs.tar.xz"
       }
     },
     "npmlock2nix": {
@@ -181,11 +181,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661553622,
-        "narHash": "sha256-qljmsjIgQXKJL2VW6V8ZMGOAYeY7dUTLgcbFqPab09U=",
+        "lastModified": 1662143203,
+        "narHash": "sha256-Jh8IOPFh1lXf2lw7mNOx2TFvLYYzviW4pN+hAhdadOo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c3836a37186a240e5792891811ff2219d8c3f7ae",
+        "rev": "b6f234155b9ae9134e804aad547ef70a191bad06",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661482898,
-        "narHash": "sha256-Z0t1eYtvS233HjC0+wrfJzcGcXyO6dRDzAiVK51e6oA=",
+        "lastModified": 1661915084,
+        "narHash": "sha256-+csJO6Ffp9A51N6GlwrhS+U35STAxNbp42vpKmaBrck=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4e28d56f904d1c60f5546bd1dbf939269e832506",
+        "rev": "790cf08a011248a881a516cadf125bbc47f1a420",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.2720.058de381857/nixexprs.tar.xz";
+    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.2818.b82ccafb541/nixexprs.tar.xz";
 
     home-manager.url = "github:nix-community/home-manager/release-22.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'impermanence':
    'github:nix-community/impermanence/e7c6fbbe9076109263175ef992ca6edc1050973c' (2022-08-22)
  → 'github:nix-community/impermanence/def994adbdfc28974e87b0e4c949e776207d5557' (2022-08-31)
• Updated input 'indexyz':
    'github:X01A/nixos/421614677e795290eb85dc491b0be559514ebe8f' (2022-08-26)
  → 'github:X01A/nixos/0f3557cb90a1de3ac5ff947ffc443b1e04acf9c7' (2022-08-31)
• Updated input 'indexyz/rust-overlay':
    'github:oxalica/rust-overlay/4e28d56f904d1c60f5546bd1dbf939269e832506' (2022-08-26)
  → 'github:oxalica/rust-overlay/790cf08a011248a881a516cadf125bbc47f1a420' (2022-08-31)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/058de3818577db19d1965c21e2479916a3eaaf95' (2022-08-25)
  → 'github:NixOS/nixpkgs/b82ccafb54163ab9024e893e578d840577785fea' (2022-09-01)
• Updated input 'nixpkgs-channel':
    'https://releases.nixos.org/nixos/22.05/nixos-22.05.2720.058de381857/nixexprs.tar.xz?narHash=sha256-im4r0AQIr5Zx1St0bMp54PdyzUhDEweBMLkxpK1p%2ftg='
  → 'https://releases.nixos.org/nixos/22.05/nixos-22.05.2818.b82ccafb541/nixexprs.tar.xz?narHash=sha256-0dnMPICO1%2f3Kb2Z4GOnrAkO+Mtsf3THauqvxSKjM9jc='
• Updated input 'nur':
    'github:nix-community/NUR/c3836a37186a240e5792891811ff2219d8c3f7ae' (2022-08-26)
  → 'github:nix-community/NUR/b6f234155b9ae9134e804aad547ef70a191bad06' (2022-09-02)