### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1662025319,
-        "narHash": "sha256-ZJlBQ7jXynq4+Jg9+DgOe8FJG8sDIeFFYP3V3K98KUs=",
+        "lastModified": 1662099760,
+        "narHash": "sha256-MdZLCTJPeHi/9fg6R9fiunyDwP3XHJqDd51zWWz9px0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b82ccafb54163ab9024e893e578d840577785fea",
+        "rev": "67e45078141102f45eff1589a831aeaa3182b41e",
         "type": "github"
       },
       "original": {
@@ -154,13 +154,13 @@
     },
     "nixpkgs-channel": {
       "locked": {
-        "narHash": "sha256-0dnMPICO1/3Kb2Z4GOnrAkO+Mtsf3THauqvxSKjM9jc=",
+        "narHash": "sha256-2n6Qsl2GmwQXg9jXPjeZEoKueg3VERLrob3odBreoMc=",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.2818.b82ccafb541/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.2889.67e45078141/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.2818.b82ccafb541/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.2889.67e45078141/nixexprs.tar.xz"
       }
     },
     "npmlock2nix": {
@@ -181,11 +181,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1662143203,
-        "narHash": "sha256-Jh8IOPFh1lXf2lw7mNOx2TFvLYYzviW4pN+hAhdadOo=",
+        "lastModified": 1662760109,
+        "narHash": "sha256-a3Sz81FzM2xvk35gjc7vxpTpBpl1725vt1tILlTXhRA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6f234155b9ae9134e804aad547ef70a191bad06",
+        "rev": "60e87040af5fe9ad024697e3c4ba68a672575dbc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.2818.b82ccafb541/nixexprs.tar.xz";
+    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.2889.67e45078141/nixexprs.tar.xz";
 
     home-manager.url = "github:nix-community/home-manager/release-22.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/b82ccafb54163ab9024e893e578d840577785fea' (2022-09-01)
  → 'github:NixOS/nixpkgs/67e45078141102f45eff1589a831aeaa3182b41e' (2022-09-02)
• Updated input 'nixpkgs-channel':
    'https://releases.nixos.org/nixos/22.05/nixos-22.05.2818.b82ccafb541/nixexprs.tar.xz?narHash=sha256-0dnMPICO1%2f3Kb2Z4GOnrAkO+Mtsf3THauqvxSKjM9jc='
  → 'https://releases.nixos.org/nixos/22.05/nixos-22.05.2889.67e45078141/nixexprs.tar.xz?narHash=sha256-2n6Qsl2GmwQXg9jXPjeZEoKueg3VERLrob3odBreoMc='
• Updated input 'nur':
    'github:nix-community/NUR/b6f234155b9ae9134e804aad547ef70a191bad06' (2022-09-02)
  → 'github:nix-community/NUR/60e87040af5fe9ad024697e3c4ba68a672575dbc' (2022-09-09)