### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -123,11 +123,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1662926104,
-        "narHash": "sha256-fBsJnGErEmr/o4ku0EKMl5Y/FVzPPZnvYALdwrP8wfY=",
+        "lastModified": 1663590310,
+        "narHash": "sha256-jlyBeEU9VysrFlkzOg3zPe6d8iWOozrRrPiyfGJFYEA=",
         "owner": "X01A",
         "repo": "nixos",
-        "rev": "f12ce066b617f0db56d313270a9a8ffe257b8eeb",
+        "rev": "d22772e7870db9c53d24c3b259b1ee983c1455be",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663244735,
-        "narHash": "sha256-+EukKkeAx6ithOLM1u5x4D12ZFuoi6vpPYjhNDmLz1o=",
+        "lastModified": 1663855239,
+        "narHash": "sha256-A2B7rlFKmBikRwz/cmayWcTAhyIOdp2whjVCDGhg9Xw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "178fea1414ae708a5704490f4c49ec3320be9815",
+        "rev": "bcc68429a50c4ac051920c72c60e417202c19d79",
         "type": "github"
       },
       "original": {
@@ -154,13 +154,13 @@
     },
     "nixpkgs-channel": {
       "locked": {
-        "narHash": "sha256-ps0C/9k6A6qfLCgAj4dnMJs8xp9phJVIHeD8Kb7/x+s=",
+        "narHash": "sha256-1amn4UDA2QjKO+GObjo78wK5AP+JSPSxlsW4+GXSHas=",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3065.178fea1414a/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3201.bcc68429a50/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3065.178fea1414a/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3201.bcc68429a50/nixexprs.tar.xz"
       }
     },
     "npmlock2nix": {
@@ -181,11 +181,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1663686586,
-        "narHash": "sha256-kf2yRPAsq+wpLLgwQKKZVm1IGWr36wUskVjdmY/RZo0=",
+        "lastModified": 1663959995,
+        "narHash": "sha256-ySFFdlwPlY7y0Awyku0K1ZY8ZLnn4WjpnyzxAUclROQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "23dfb5e4a9c61a59a5d6d2a1819a87a0643eea53",
+        "rev": "e6c4481bfcf49994341432bef14e947238edc674",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.3065.178fea1414a/nixexprs.tar.xz";
+    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.3201.bcc68429a50/nixexprs.tar.xz";
 
     home-manager.url = "github:nix-community/home-manager/release-22.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'indexyz':
    'github:X01A/nixos/f12ce066b617f0db56d313270a9a8ffe257b8eeb' (2022-09-11)
  → 'github:X01A/nixos/d22772e7870db9c53d24c3b259b1ee983c1455be' (2022-09-19)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/178fea1414ae708a5704490f4c49ec3320be9815' (2022-09-15)
  → 'github:NixOS/nixpkgs/bcc68429a50c4ac051920c72c60e417202c19d79' (2022-09-22)
• Updated input 'nixpkgs-channel':
    'https://releases.nixos.org/nixos/22.05/nixos-22.05.3065.178fea1414a/nixexprs.tar.xz?narHash=sha256-ps0C%2f9k6A6qfLCgAj4dnMJs8xp9phJVIHeD8Kb7%2fx+s='
  → 'https://releases.nixos.org/nixos/22.05/nixos-22.05.3201.bcc68429a50/nixexprs.tar.xz?narHash=sha256-1amn4UDA2QjKO+GObjo78wK5AP+JSPSxlsW4+GXSHas='
• Updated input 'nur':
    'github:nix-community/NUR/23dfb5e4a9c61a59a5d6d2a1819a87a0643eea53' (2022-09-20)
  → 'github:nix-community/NUR/e6c4481bfcf49994341432bef14e947238edc674' (2022-09-23)