### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663855239,
-        "narHash": "sha256-A2B7rlFKmBikRwz/cmayWcTAhyIOdp2whjVCDGhg9Xw=",
+        "lastModified": 1664438633,
+        "narHash": "sha256-qEotLz24HnHhgmba4drLHIxXG+IKQ7uve5GjUhjWhTU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcc68429a50c4ac051920c72c60e417202c19d79",
+        "rev": "13cbe534ebe63a0bc2619c57661a2150569d0443",
         "type": "github"
       },
       "original": {
@@ -154,13 +154,13 @@
     },
     "nixpkgs-channel": {
       "locked": {
-        "narHash": "sha256-1amn4UDA2QjKO+GObjo78wK5AP+JSPSxlsW4+GXSHas=",
+        "narHash": "sha256-CdEFe1XCrhPqkXE00gz6n8K/Ruf9ab8ovYRz8q85rJ8=",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3201.bcc68429a50/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3373.13cbe534ebe/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3201.bcc68429a50/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3373.13cbe534ebe/nixexprs.tar.xz"
       }
     },
     "npmlock2nix": {
@@ -181,11 +181,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1663959995,
-        "narHash": "sha256-ySFFdlwPlY7y0Awyku0K1ZY8ZLnn4WjpnyzxAUclROQ=",
+        "lastModified": 1664570653,
+        "narHash": "sha256-nDFI1nPRHkOAzjO662QmSS6sn/qF7tvuJRnYT7ixZec=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e6c4481bfcf49994341432bef14e947238edc674",
+        "rev": "0ce7cfc07ec92b63e6c71188f78eaa912c385eed",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.3201.bcc68429a50/nixexprs.tar.xz";
+    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.3373.13cbe534ebe/nixexprs.tar.xz";
 
     home-manager.url = "github:nix-community/home-manager/release-22.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/bcc68429a50c4ac051920c72c60e417202c19d79' (2022-09-22)
  → 'github:NixOS/nixpkgs/13cbe534ebe63a0bc2619c57661a2150569d0443' (2022-09-29)
• Updated input 'nixpkgs-channel':
    'https://releases.nixos.org/nixos/22.05/nixos-22.05.3201.bcc68429a50/nixexprs.tar.xz?narHash=sha256-1amn4UDA2QjKO+GObjo78wK5AP+JSPSxlsW4+GXSHas='
  → 'https://releases.nixos.org/nixos/22.05/nixos-22.05.3373.13cbe534ebe/nixexprs.tar.xz?narHash=sha256-CdEFe1XCrhPqkXE00gz6n8K%2fRuf9ab8ovYRz8q85rJ8='
• Updated input 'nur':
    'github:nix-community/NUR/e6c4481bfcf49994341432bef14e947238edc674' (2022-09-23)
  → 'github:nix-community/NUR/0ce7cfc07ec92b63e6c71188f78eaa912c385eed' (2022-09-30)