### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664438633,
-        "narHash": "sha256-qEotLz24HnHhgmba4drLHIxXG+IKQ7uve5GjUhjWhTU=",
+        "lastModified": 1665066044,
+        "narHash": "sha256-mkO0LMHVunMFRWLcJhHT0fBf2v6RlH3vg7EVpfSIAFc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13cbe534ebe63a0bc2619c57661a2150569d0443",
+        "rev": "ed9b904c5eba055a6d6f5c1ccb89ba8f0a056dc6",
         "type": "github"
       },
       "original": {
@@ -154,13 +154,13 @@
     },
     "nixpkgs-channel": {
       "locked": {
-        "narHash": "sha256-CdEFe1XCrhPqkXE00gz6n8K/Ruf9ab8ovYRz8q85rJ8=",
+        "narHash": "sha256-IcGVL3H7fkltaO2qQsfm95V0lhmT3/nJQd5dwo09QdQ=",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3373.13cbe534ebe/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3475.ed9b904c5eb/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3373.13cbe534ebe/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3475.ed9b904c5eb/nixexprs.tar.xz"
       }
     },
     "npmlock2nix": {
@@ -181,11 +181,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1664570653,
-        "narHash": "sha256-nDFI1nPRHkOAzjO662QmSS6sn/qF7tvuJRnYT7ixZec=",
+        "lastModified": 1665151116,
+        "narHash": "sha256-JTrA3EpOe94e/k/8A5JKkI0pmVqEDiM+zQcJq4neDJk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ce7cfc07ec92b63e6c71188f78eaa912c385eed",
+        "rev": "04af34e85a9b2cf753d3c59d111f8f7d2f212dfe",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.3373.13cbe534ebe/nixexprs.tar.xz";
+    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.3475.ed9b904c5eb/nixexprs.tar.xz";
 
     home-manager.url = "github:nix-community/home-manager/release-22.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/13cbe534ebe63a0bc2619c57661a2150569d0443' (2022-09-29)
  → 'github:NixOS/nixpkgs/ed9b904c5eba055a6d6f5c1ccb89ba8f0a056dc6' (2022-10-06)
• Updated input 'nixpkgs-channel':
    'https://releases.nixos.org/nixos/22.05/nixos-22.05.3373.13cbe534ebe/nixexprs.tar.xz?narHash=sha256-CdEFe1XCrhPqkXE00gz6n8K%2fRuf9ab8ovYRz8q85rJ8='
  → 'https://releases.nixos.org/nixos/22.05/nixos-22.05.3475.ed9b904c5eb/nixexprs.tar.xz?narHash=sha256-IcGVL3H7fkltaO2qQsfm95V0lhmT3%2fnJQd5dwo09QdQ='
• Updated input 'nur':
    'github:nix-community/NUR/0ce7cfc07ec92b63e6c71188f78eaa912c385eed' (2022-09-30)
  → 'github:nix-community/NUR/04af34e85a9b2cf753d3c59d111f8f7d2f212dfe' (2022-10-07)