### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665475263,
-        "narHash": "sha256-T4at7d+KsQNWh5rfjvOtQCaIMWjSDlSgQZKvxb+LcEY=",
+        "lastModified": 1665996265,
+        "narHash": "sha256-/k9og6LDBQwT+f/tJ5ClcWiUl8kCX5m6ognhsAxOiCY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "17208be516fc36e2ab0ceb064d931e90eb88b2a3",
+        "rev": "b81e128fc053ab3159d7b464d9b7dedc9d6a6891",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1665676086,
-        "narHash": "sha256-Z/fVmgXMjUU+dWxQHucXP7boO4geH2kNtrsCVCHc+sY=",
+        "lastModified": 1666281610,
+        "narHash": "sha256-RLoLNYefKHk3Eip/O78sbsAUlRUZXONEj9mffkA+wr0=",
         "owner": "X01A",
         "repo": "nixos",
-        "rev": "4cde59790738268b23b96ab6e95fdf9d8b9c1575",
+        "rev": "8a97902942fdaac6398a32e405d5b1bb04d6a3d0",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665613119,
-        "narHash": "sha256-VTutbv5YKeBGWou6ladtgfx11h6et+Wlkdyh4jPJ3p0=",
+        "lastModified": 1666249138,
+        "narHash": "sha256-CzK8NA8xEMKAhvHXB8UMODckcH97sZXm6lziKNWLv0M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e06bd4b64bbfda91d74f13cb5eca89485d47528f",
+        "rev": "44fc3cb097324c9f9f93313dd3f103e78d722968",
         "type": "github"
       },
       "original": {
@@ -154,23 +154,23 @@
     },
     "nixpkgs-channel": {
       "locked": {
-        "narHash": "sha256-rAo2sR3WlpKTUjKTxeBJlT6xqxoVrbrMlBIm5pAPOGA=",
+        "narHash": "sha256-rA911ozyDcfCBDr7PtRiKVgvHfqUAlKOhxBuiDuhxYg=",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3620.e06bd4b64bb/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3705.44fc3cb0973/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3620.e06bd4b64bb/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3705.44fc3cb0973/nixexprs.tar.xz"
       }
     },
     "npmlock2nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1654787802,
-        "narHash": "sha256-53wPtqRsiaR8e3njRHZbO4lPX1W9hHdTarHEx6gE/s0=",
+        "lastModified": 1664286682,
+        "narHash": "sha256-OBdpqW2zpwYF/JWUk013rbMdIC3R17ynX78tQPbfHNw=",
         "owner": "serokell",
         "repo": "nix-npm-buildpackage",
-        "rev": "ec9a825ad4a6f1fb2d6bb8371be827c9c8bf5b80",
+        "rev": "bc0c4989f664ff262d3ab39cad9dc0f6f1c10017",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665788726,
-        "narHash": "sha256-6kRYefjO1xnV5pktALYKdH+J3F1c6Es8P3Tdy7BXf8s=",
+        "lastModified": 1666389035,
+        "narHash": "sha256-BX+U9l+SNLCigBhprxYW26Tz1pVu+6Ab8zW1HRU+PcE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be40fb543c7445a8827da43d59cdd1dedf783f56",
+        "rev": "520df33879c5693caeefb9b3347b530e83dcc540",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661915084,
-        "narHash": "sha256-+csJO6Ffp9A51N6GlwrhS+U35STAxNbp42vpKmaBrck=",
+        "lastModified": 1666148516,
+        "narHash": "sha256-pFgSJzUFsnCTulIzhn3HHImaZpqlMxAvXTrhg0qlMOE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "790cf08a011248a881a516cadf125bbc47f1a420",
+        "rev": "3e41700ab6f585b9569112ee7516c74f8d072989",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.3620.e06bd4b64bb/nixexprs.tar.xz";
+    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.3705.44fc3cb0973/nixexprs.tar.xz";
 
     home-manager.url = "github:nix-community/home-manager/release-22.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/17208be516fc36e2ab0ceb064d931e90eb88b2a3' (2022-10-11)
  → 'github:nix-community/home-manager/b81e128fc053ab3159d7b464d9b7dedc9d6a6891' (2022-10-17)
• Updated input 'indexyz':
    'github:X01A/nixos/4cde59790738268b23b96ab6e95fdf9d8b9c1575' (2022-10-13)
  → 'github:X01A/nixos/8a97902942fdaac6398a32e405d5b1bb04d6a3d0' (2022-10-20)
• Updated input 'indexyz/npmlock2nix':
    'github:serokell/nix-npm-buildpackage/ec9a825ad4a6f1fb2d6bb8371be827c9c8bf5b80' (2022-06-09)
  → 'github:serokell/nix-npm-buildpackage/bc0c4989f664ff262d3ab39cad9dc0f6f1c10017' (2022-09-27)
• Updated input 'indexyz/rust-overlay':
    'github:oxalica/rust-overlay/790cf08a011248a881a516cadf125bbc47f1a420' (2022-08-31)
  → 'github:oxalica/rust-overlay/3e41700ab6f585b9569112ee7516c74f8d072989' (2022-10-19)
• Updated input 'indexyz/rust-overlay/flake-utils':
    'github:numtide/flake-utils/7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249' (2022-07-04)
  → 'github:numtide/flake-utils/c0e246b9b83f637f4681389ecabcb2681b4f3af0' (2022-08-07)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/e06bd4b64bbfda91d74f13cb5eca89485d47528f' (2022-10-12)
  → 'github:NixOS/nixpkgs/44fc3cb097324c9f9f93313dd3f103e78d722968' (2022-10-20)
• Updated input 'nixpkgs-channel':
    'https://releases.nixos.org/nixos/22.05/nixos-22.05.3620.e06bd4b64bb/nixexprs.tar.xz?narHash=sha256-rAo2sR3WlpKTUjKTxeBJlT6xqxoVrbrMlBIm5pAPOGA='
  → 'https://releases.nixos.org/nixos/22.05/nixos-22.05.3705.44fc3cb0973/nixexprs.tar.xz?narHash=sha256-rA911ozyDcfCBDr7PtRiKVgvHfqUAlKOhxBuiDuhxYg='
• Updated input 'nur':
    'github:nix-community/NUR/be40fb543c7445a8827da43d59cdd1dedf783f56' (2022-10-14)
  → 'github:nix-community/NUR/520df33879c5693caeefb9b3347b530e83dcc540' (2022-10-21)